### PR TITLE
Add generic error constructor

### DIFF
--- a/functions.go
+++ b/functions.go
@@ -24,6 +24,10 @@ func NotFound(message string, details ...Detail) Error {
 	return newBerr(NotFoundErrorType, message, details...)
 }
 
+func New(errType ErrorType, message string, details ...Detail) Error {
+	return newBerr(errType, message, details...)
+}
+
 func D(key string, value any) Detail {
 	return detail{key: key, value: value}
 }


### PR DESCRIPTION
Exposing a generic `New` constructor allows developers to better leave a trail of breadcrumbs to the error while also maintaining the error type easily. In the example below, one of the following must be sacrificed: a wrapping error message, error type, or concise code.

Current world:
```go
func doSomethingGeneral() berr.Error {
    if err := doSomethingSpecific(); err != nil {
        // either do this; sacrificing a wrapping error message
        return err

        // or this; sacrificing the error type
        return berr.Application("problem doing something general", berr.E(err))

        // or this; sacrificing concise code
        switch err.Type() {
        case berr.NotFoundType:
            return berr.NotFound("problem doing something general", berr.E(err))
        ...
        }
    }
}

func doSomethingSpecific() berr.Error {
    return berr.SomeErrorType("problem doing something specific")
}
```

Proposed world:
```go
func doSomethingGeneral() berr.Error {
    if err := doSomethingSpecific(); err != nil {
        return berr.New(err.Type(), "problem doing something general", berr.E(err))
    }
}

func doSomethingSpecific() berr.Error {
    return berr.SomeErrorType("problem doing something specific")
}
```